### PR TITLE
Use overflow-wrap: break-word for post style to prevent x-axis scroll

### DIFF
--- a/_sass/plain.scss
+++ b/_sass/plain.scss
@@ -163,6 +163,7 @@ main {
 	font-weight: 300;
 	color: #222;
 	line-height: 1.9em;
+	overflow-wrap: break-word;
 	a {
 		color: $linkColor;
 		text-decoration: none;


### PR DESCRIPTION
안녕하세요. 트위터에서 (복합형질과 동성애)[https://hanbin973.github.io/2019/07/28/complexhomo.html]라는 글을 보고 재미있게 읽었습니다. 좋은 글 감사합니다.

핸드폰으로 보다보니 너무 긴 링크가 있어서 가로 스크롤이 생기는 걸 확인해서 해당 문제를 해결하는 PR을 보내봅니다. [overflow-wrap](https://developer.mozilla.org/ko/docs/Web/CSS/overflow-wrap)은 한 단어가 컨테이너의 너비 이상으로 넘칠 때 처리를 지정하는 속성입니다.

as-is (가로 스크롤이 생긴 상태)
![스크린샷 2019-08-11 오후 2 27 03](https://user-images.githubusercontent.com/6768840/62830194-6385f700-bc45-11e9-9368-f81875a73858.png)

적용될 시 to-be
![스크린샷 2019-08-11 오후 2 26 54](https://user-images.githubusercontent.com/6768840/62830195-6385f700-bc45-11e9-8f56-1af37a2f5374.png)

혹시 괜찮은 것 같다면 머지해주시고, 필요 없으시다면 편하게 닫아주세요. 감사합니다~!